### PR TITLE
Nfp backlash comp macro

### DIFF
--- a/printer.cfg
+++ b/printer.cfg
@@ -159,11 +159,11 @@ hold_current: 0.4
 
 [gcode_macro COMPENSATED_ABS_MV]
 description: Absolute X/Y move with backlash takeup when changing into negative direction
-variable_backlash: 0.05
+variable_backlash: 10
 gcode:
     {% set target_x = params.X|default(printer.toolhead.position.x)|float %}
     {% set target_y = params.Y|default(printer.toolhead.position.y)|float %}
-    {% set f = params.F|default(3000)|float %}
+    {% set f = params.F|default(9000)|float %}
 
     {% set current_x = printer.toolhead.position.x|float %}
     {% set current_y = printer.toolhead.position.y|float %}

--- a/printer.cfg
+++ b/printer.cfg
@@ -192,6 +192,13 @@ gcode:
 
     RESTORE_GCODE_STATE NAME=prior_state
 
+[gcode_macro SET_BACKLASH]
+description: Set backlash compensation amount (in mm)
+gcode:
+    {% set val = params.VALUE|float %}
+    SET_GCODE_VARIABLE MACRO=COMPENSATED_ABS_MV VARIABLE=backlash VALUE={val}
+    RESPOND MSG="Backlash set to {val} mm"
+
 [printer]
 kinematics: generic_cartesian
 max_velocity: 15

--- a/printer.cfg
+++ b/printer.cfg
@@ -157,6 +157,41 @@ hold_current: 0.4
 # run_current: 0.9
 # hold_current: 0.4
 
+[gcode_macro COMPENSATED_ABS_MV]
+description: Absolute X/Y move with backlash takeup when changing into negative direction
+variable_backlash: 0.05
+gcode:
+    {% set target_x = params.X|default(printer.toolhead.position.x)|float %}
+    {% set target_y = params.Y|default(printer.toolhead.position.y)|float %}
+    {% set f = params.F|default(3000)|float %}
+
+    {% set current_x = printer.toolhead.position.x|float %}
+    {% set current_y = printer.toolhead.position.y|float %}
+
+    {% set backlash = printer["gcode_macro COMPENSATED_ABS_MV"].backlash|float %}
+
+    SAVE_GCODE_STATE NAME=prior_state
+
+    G90 # Absolute Move Mode
+
+    # ----- X axis -----
+    {% if target_x < current_x %}
+        G1 X{target_x - backlash} F{f}
+        G1 X{target_x} F{f}
+    {% elif target_x > current_x %}
+        G1 X{target_x} F{f}
+    {% endif %}
+
+    # ----- Y axis -----
+    {% if target_y < current_y %}
+        G1 Y{target_y - backlash} F{f}
+        G1 Y{target_y} F{f}
+    {% elif target_y > current_y %}
+        G1 Y{target_y} F{f}
+    {% endif %}
+
+    RESTORE_GCODE_STATE NAME=prior_state
+
 [printer]
 kinematics: generic_cartesian
 max_velocity: 15

--- a/src/CarriageController.py
+++ b/src/CarriageController.py
@@ -92,8 +92,8 @@ class CarriageController:
         2. Set dual carriage to T1 (x2/y2), move X/Y (mapped to X2/Y2).
         
         Klipper Dual Carriage usually mapping:
-        SET_DUAL_CARRIAGE CARRIAGE=x  -> G1 X.. moves X1
-        SET_DUAL_CARRIAGE CARRIAGE=x2 -> G1 X.. moves X2
+        SET_DUAL_CARRIAGE CARRIAGE=x  -> COMPENSATED_ABS_MV X.. moves X1
+        SET_DUAL_CARRIAGE CARRIAGE=x2 -> COMPENSATED_ABS_MV X.. moves X2
         """
         # Clamp positions before sending
         cx1 = self._clamp_position('x1', x1)
@@ -110,7 +110,7 @@ class CarriageController:
         await self.client.send_gcode_and_wait("SET_DUAL_CARRIAGE CARRIAGE=y") 
         
         # Move C1
-        await self.client.send_gcode(f"G1 X{cx1} Y{cy1} F{speed}")
+        await self.client.send_gcode(f"COMPENSATED_ABS_MV X={cx1} Y={cy1} F={speed}")
         
         # Move Carriage 2 (cx2, cy2)
         # Activate Carriage 2 - MUST WAIT for this to complete
@@ -118,7 +118,7 @@ class CarriageController:
         await self.client.send_gcode_and_wait("SET_DUAL_CARRIAGE CARRIAGE=y2")
         
         # Move C2
-        await self.client.send_gcode(f"G1 X{cx2} Y{cy2} F{speed}")
+        await self.client.send_gcode(f"COMPENSATED_ABS_MV X={cx2} Y={cy2} F={speed}")
         
         # Update internal state with clamped values
         self.positions['x1'] = cx1
@@ -181,7 +181,7 @@ class CarriageController:
         await self.client.send_gcode_and_wait(f"SET_DUAL_CARRIAGE CARRIAGE={cy_name}")
         
         # Move
-        await self.client.send_gcode(f"G1 X{clamped_x} Y{clamped_y} F{speed}")
+        await self.client.send_gcode(f"COMPENSATED_ABS_MV X={clamped_x} Y={clamped_y} F={speed}")
         
         # Update State
         self.positions[cx_key] = clamped_x


### PR DESCRIPTION
added 2 Macros:
1) COMPENSATED_ABS_MV
- an absolute movement command for X and Y that automatically compensates for backlash in negative x and y movements
2) SET_BACKLASH
- allows us to set the backlash distance (mm) (default 10)